### PR TITLE
Change default style and allow style overrides

### DIFF
--- a/d2l-progress.js
+++ b/d2l-progress.js
@@ -22,7 +22,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-progress">
 			#progressContainer {
 				@apply --d2l-progress-container;
 				position: relative;
-				height: var(--d2l-progress-height, 4px);
+				height: var(--d2l-progress-height, 6px);
 				background: var(--d2l-progress-container-color, var(--d2l-color-gypsum));
 			}
 

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -133,7 +133,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 
 		</style>
 
-		<div id="sliderContainer" fullWidth$="{{fullWidth}}">
+		<div id="sliderContainer" fullWidth$="[[fullWidth]]">
 			<div class="bar-container">
 				<d2l-progress id="sliderBar" value="{{immediateValue}}" on-down="_barDown" on-up="_barUp" on-track="_onTrack"></d2l-progress>
 			</div>

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -30,6 +30,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				--calculated-d2l-outer-knob-border-color: var(--d2l-outer-knob-border-color, var(--d2l-color-pressicus));
 				--calculated-d2l-inner-knob-color: var(--d2l-inner-knob-color, var(--d2l-color-celestine));
 				--calculated-d2l-progress-border-color: var(--d2l-progress-border-color, var(--d2l-color-pressicus));
+				--calculated-d2l-progress-border-radius: var(--d2l-progress-border-radius, 4px);
 				--calculated-d2l-progress-shadow-color: var(--d2l-progress-shadow-color, #dadee3);
 				--calculated-d2l-progress-background-color: var(--d2l-progress-background-color, var(--d2l-color-gypsum));
 				--calculated-d2l-progress-active-color: var(--d2l-progress-active-color, var(--d2l-color-gypsum));
@@ -72,7 +73,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				}
 				--d2l-progress-container: {
 					border: 1px solid var(--calculated-d2l-progress-border-color);
-					border-radius: 4px;
+					border-radius: var(--calculated-d2l-progress-border-radius);
 					box-shadow: inset 0 1px 0 0 var(--calculated-d2l-progress-shadow-color);
 				}
 				--d2l-progress-container-color: var(--calculated-d2l-progress-background-color);

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -24,7 +24,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				--d2l-color-corundum-65-opacity: rgba(181, 189, 194, 0.65);
 				--d2l-color-galena-88-opacity: rgba(134, 140, 143, 0.88);
 
-				--calculated-d2l-seek-bar-height: var(--d2l-seek-bar-height, 4px);
+				--calculated-d2l-seek-bar-height: var(--d2l-seek-bar-height, 6px);
 				--calculated-d2l-knob-size: var(--d2l-knob-size, 32px);
 				--half-knob-size: calc(var(--calculated-d2l-knob-size)/2);
 				--half-knob-size-overflow: calc((var(--calculated-d2l-knob-size) - var(--calculated-d2l-seek-bar-height)) / 2 - 1px);
@@ -37,7 +37,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				--calculated-d2l-knob-focus-size: var(--d2l-knob-focus-size, 2px);
 				--calculated-d2l-progress-background-color: var(--d2l-progress-background-color, var(--d2l-color-corundum-65-opacity));
 				--calculated-d2l-progress-border-color: var(--d2l-progress-border-color, var(--d2l-color-pressicus));
-				--calculated-d2l-progress-border-radius: var(--d2l-progress-border-radius, 4px);
+				--calculated-d2l-progress-border-radius: var(--d2l-progress-border-radius, 6px);
 				--calculated-d2l-progress-shadow-color: var(--d2l-progress-shadow-color, var(--d2l-color-galena-88-opacity));
 				--calculated-d2l-progress-active-color: var(--d2l-progress-active-color, var(--d2l-color-celestine-plus-1));
 			}
@@ -83,7 +83,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				padding: var(--half-knob-size-overflow) 0;
 				width: 100%;
 				--d2l-progress-primary: {
-					border-radius: 4px;
+					border-radius: var(--calculated-d2l-progress-border-radius);
 					box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, 0.07);
 				}
 				--d2l-progress-container: {

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -53,6 +53,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				margin-right: var(--half-knob-size);
 			}
 
+			:host([fullWidth]) #sliderContainer {
+				margin-left: 0;
+				margin-right: 0;
+			}
+
 			.bar-container {
 				@apply --layout-fit;
 				overflow: hidden;
@@ -100,7 +105,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 
 		</style>
 
-		<div id="sliderContainer">
+		<div id="sliderContainer" fullWidth$="{{fullWidth}}">
 			<div class="bar-container">
 				<d2l-progress id="sliderBar" value="{{immediateValue}}" on-down="_barDown" on-up="_barUp" on-track="_onTrack"></d2l-progress>
 			</div>
@@ -140,6 +145,11 @@ Polymer({
 			type: Boolean,
 			value: false
 		},
+
+		fullWidth: {
+			type: Boolean,
+			value: false
+		}
 	},
 
 	hostAttributes: {

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -68,9 +68,23 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				margin-right: var(--half-knob-size);
 			}
 
+			#knobContainer {
+				pointer-events: none;
+				position: absolute;
+				top: 0;
+				bottom: 0;
+				left: 0;
+				right: 0;
+			}
+
 			:host([fullWidth]) #sliderContainer {
 				margin-left: 0;
 				margin-right: 0;
+			}
+
+			:host([fullWidth]) #knobContainer {
+				left: var(--half-knob-size);
+				right: var(--half-knob-size);
 			}
 
 			.bar-container {
@@ -123,8 +137,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 			<div class="bar-container">
 				<d2l-progress id="sliderBar" value="{{immediateValue}}" on-down="_barDown" on-up="_barUp" on-track="_onTrack"></d2l-progress>
 			</div>
-			<div id="sliderKnob" class="slider-knob" on-down="_knobDown" on-track="_onTrack">
-				<div class="slider-knob-inner"></div>
+			<div id="knobContainer">
+				<div id="sliderKnob" class="slider-knob" on-down="_knobDown" on-track="_onTrack">
+					<div class="slider-knob-inner"></div>
+				</div>
 			</div>
 		</div>
 	</template>
@@ -256,7 +272,7 @@ Polymer({
 	},
 
 	_trackStart: function() {
-		this._w = this.$.sliderBar.offsetWidth;
+		this._w = this.$.knobContainer.offsetWidth;
 		this._x = this.ratio * this._w;
 		this._startx = this._x;
 		this._knobstartx = this._startx;
@@ -291,8 +307,8 @@ Polymer({
 	},
 
 	_barDown: function(event) {
-		this._w = this.$.sliderBar.offsetWidth;
-		var rect = this.$.sliderBar.getBoundingClientRect();
+		this._w = this.$.knobContainer.offsetWidth;
+		var rect = this.$.knobContainer.getBoundingClientRect();
 
 		var mousePosition = this.vertical ? rect.bottom - event.detail.y : event.detail.x - rect.left;
 		var ratio = mousePosition / this._w;

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -20,6 +20,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				@apply --layout-justified;
 				@apply --layout-center;
 				display: block;
+
+				--d2l-color-corundum-65-opacity: rgba(181, 189, 194, 0.65);
+				--d2l-color-galena-88-opacity: rgba(134, 140, 143, 0.88);
+
 				--calculated-d2l-seek-bar-height: var(--d2l-seek-bar-height, 4px);
 				--calculated-d2l-knob-size: var(--d2l-knob-size, 32px);
 				--half-knob-size: calc(var(--calculated-d2l-knob-size)/2);
@@ -31,10 +35,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				--calculated-d2l-inner-knob-color: var(--d2l-inner-knob-color, var(--d2l-color-celestine-plus-1));
 				--calculated-d2l-knob-focus-color: var(--d2l-knob-focus-color, var(--d2l-color-celestine));
 				--calculated-d2l-knob-focus-size: var(--d2l-knob-focus-size, 2px);
-				--calculated-d2l-progress-background-color: var(--d2l-progress-background-color, var(--d2l-color-corundum));
+				--calculated-d2l-progress-background-color: var(--d2l-progress-background-color, var(--d2l-color-corundum-65-opacity));
 				--calculated-d2l-progress-border-color: var(--d2l-progress-border-color, var(--d2l-color-pressicus));
 				--calculated-d2l-progress-border-radius: var(--d2l-progress-border-radius, 4px);
-				--calculated-d2l-progress-shadow-color: var(--d2l-progress-shadow-color, var(--d2l-color-galena));
+				--calculated-d2l-progress-shadow-color: var(--d2l-progress-shadow-color, var(--d2l-color-galena-88-opacity));
 				--calculated-d2l-progress-active-color: var(--d2l-progress-active-color, var(--d2l-color-celestine-plus-1));
 			}
 

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -32,10 +32,17 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				--calculated-d2l-progress-border-color: var(--d2l-progress-border-color, var(--d2l-color-pressicus));
 				--calculated-d2l-progress-shadow-color: var(--d2l-progress-shadow-color, #dadee3);
 				--calculated-d2l-progress-background-color: var(--d2l-progress-background-color, var(--d2l-color-gypsum));
+				--calculated-d2l-progress-active-color: var(--d2l-progress-active-color, var(--d2l-color-gypsum));
 			}
 
 			:host(:focus) {
-				background: var(--d2l-color-regolith);
+				outline: none;
+				/* background: var(--d2l-color-regolith); */
+				/* outline: 2px solid var(--d2l-color-celestine); */
+			}
+
+			:host(:focus) .slider-knob {
+				/* outline: 2px solid white; */
 				outline: 2px solid var(--d2l-color-celestine);
 			}
 
@@ -64,7 +71,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 					box-shadow: inset 0 1px 0 0 var(--calculated-d2l-progress-shadow-color);
 				}
 				--d2l-progress-container-color: var(--calculated-d2l-progress-background-color);
-				--d2l-progress-active-color: transparent;
+				--d2l-progress-active-color: var(--calculated-d2l-progress-active-color);
 			}
 
 			.slider-knob {

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -38,13 +38,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 
 			:host(:focus) {
 				outline: none;
-				/* background: var(--d2l-color-regolith); */
-				/* outline: 2px solid var(--d2l-color-celestine); */
 			}
 
 			:host(:focus) .slider-knob {
-				/* outline: 2px solid white; */
-				outline: 2px solid var(--d2l-color-celestine);
+				outline: 2px solid white;
 			}
 
 			#sliderContainer {

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -24,24 +24,37 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				--calculated-d2l-knob-size: var(--d2l-knob-size, 32px);
 				--half-knob-size: calc(var(--calculated-d2l-knob-size)/2);
 				--half-knob-size-overflow: calc((var(--calculated-d2l-knob-size) - var(--calculated-d2l-seek-bar-height)) / 2 - 1px);
-				--calculated-inner-knob-margin: var(--d2l-inner-knob-margin, 9px);
-				--calculated-d2l-knob-box-shadow: var(--d2l-knob-box-shadow, none);
+				--calculated-inner-knob-margin: var(--d2l-inner-knob-margin, 8px);
+				--calculated-d2l-knob-box-shadow: var(--d2l-knob-box-shadow, 0 2px 4px 0 rgba(0, 0, 0, 0.52));
 				--calculated-d2l-outer-knob-color: var(--d2l-outer-knob-color, var(--d2l-color-regolith));
 				--calculated-d2l-outer-knob-border-color: var(--d2l-outer-knob-border-color, var(--d2l-color-pressicus));
-				--calculated-d2l-inner-knob-color: var(--d2l-inner-knob-color, var(--d2l-color-celestine));
+				--calculated-d2l-inner-knob-color: var(--d2l-inner-knob-color, var(--d2l-color-celestine-plus-1));
+				--calculated-d2l-knob-focus-color: var(--d2l-knob-focus-color, var(--d2l-color-celestine));
+				--calculated-d2l-knob-focus-size: var(--d2l-knob-focus-size, 2px);
+				--calculated-d2l-progress-background-color: var(--d2l-progress-background-color, var(--d2l-color-corundum));
 				--calculated-d2l-progress-border-color: var(--d2l-progress-border-color, var(--d2l-color-pressicus));
 				--calculated-d2l-progress-border-radius: var(--d2l-progress-border-radius, 4px);
-				--calculated-d2l-progress-shadow-color: var(--d2l-progress-shadow-color, #dadee3);
-				--calculated-d2l-progress-background-color: var(--d2l-progress-background-color, var(--d2l-color-gypsum));
-				--calculated-d2l-progress-active-color: var(--d2l-progress-active-color, var(--d2l-color-gypsum));
+				--calculated-d2l-progress-shadow-color: var(--d2l-progress-shadow-color, var(--d2l-color-galena));
+				--calculated-d2l-progress-active-color: var(--d2l-progress-active-color, var(--d2l-color-celestine-plus-1));
 			}
 
 			:host(:focus) {
 				outline: none;
 			}
 
-			:host(:focus) .slider-knob {
-				outline: 2px solid white;
+			:host(:focus) .slider-knob:after {
+				content: '';
+				position: absolute;
+				top: 0;
+				right: 0;
+				bottom: 0;
+				left: 0;
+				border-radius: 50%;
+				box-shadow: 0 0 0 var(--calculated-d2l-knob-focus-size) var(--calculated-d2l-knob-focus-color);
+			}
+
+			:host([solid]) .slider-knob-inner  {
+				display: none;
 			}
 
 			#sliderContainer {
@@ -67,9 +80,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				width: 100%;
 				--d2l-progress-primary: {
 					border-radius: 4px;
+					box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, 0.07);
 				}
 				--d2l-progress-container: {
-					border: 1px solid var(--calculated-d2l-progress-border-color);
 					border-radius: var(--calculated-d2l-progress-border-radius);
 					box-shadow: inset 0 1px 0 0 var(--calculated-d2l-progress-shadow-color);
 				}
@@ -85,7 +98,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				width: calc((((var(--calculated-d2l-knob-size) / 2) - var(--calculated-d2l-seek-bar-height) / 2) * 2) + var(--calculated-d2l-seek-bar-height) - 2px);
 				height: calc((((var(--calculated-d2l-knob-size) / 2) - var(--calculated-d2l-seek-bar-height) / 2) * 2) + var(--calculated-d2l-seek-bar-height) - 2px);
 				background-color: var(--calculated-d2l-outer-knob-color);
-				border: 1px solid var(--calculated-d2l-outer-knob-border-color);
 				box-shadow: var(--calculated-d2l-knob-box-shadow);
 				border-radius: 50%;
 				cursor: pointer;
@@ -96,9 +108,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				width: calc(100% - var(--calculated-inner-knob-margin)*2);
 				height: calc(100% - var(--calculated-inner-knob-margin)*2);
 				background-color: var(--calculated-d2l-inner-knob-color);
-				border: 2px solid var(--calculated-d2l-inner-knob-color);
 				border-radius: 50%;
 				box-sizing: border-box;
+				box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.07)
 			}
 
 		</style>

--- a/demo/index.html
+++ b/demo/index.html
@@ -48,7 +48,7 @@
 
 			$_documentContainer.innerHTML = `<demo-snippet>
 			<template>
-				<d2l-seek-bar value="60"></d2l-seek-bar>
+				<d2l-seek-bar value="60" fullWidth></d2l-seek-bar>
 			</template>
 		</demo-snippet>`;
 
@@ -100,6 +100,26 @@
 						<label>Ratio <input type="number" value="{{seekBarRatio::input}}"></label><br>
 						<label>Step <input type="number" value="{{seekBarStep::input}}"></label><br>
 						<label>Value <input type="number" value="{{seekBarValue::input}}"></label><br>
+					</template>
+				</dom-bind>
+			</template>
+		</demo-snippet>`;
+
+			document.body.appendChild($_documentContainer.content);
+		</script>
+		<script type="module">
+			const $_documentContainer = document.createElement('template');
+			$_documentContainer.innerHTML = '<h2>Seek bar with full width</h2>';
+			document.body.appendChild($_documentContainer.content);
+		</script>
+		<script type="module">
+			const $_documentContainer = document.createElement('template');
+
+			$_documentContainer.innerHTML = `<demo-snippet>
+			<template>
+				<dom-bind>
+					<template is="dom-bind">
+						<d2l-seek-bar style="border: 1px solid #ddd;" value="60" fullWidth></d2l-seek-bar>
 					</template>
 				</dom-bind>
 			</template>


### PR DESCRIPTION
## Rationale
Towards a design refresh of `d2l-video` and `d2l-audio`, some changes/enhancements were needed for this component.

## Changes
- Change some default sizes/colors
- Allow the knob to have different focus styles
- Allow the progress bar to extend the full width of its parent (left/right margins to compensate knob size)
  - needed for `d2l-video`
  - <img width="269" alt="Screen Shot 2020-06-29 at 9 42 21 AM" src="https://user-images.githubusercontent.com/13937038/86019902-d7132d00-b9ec-11ea-8501-f59f624fe560.png">



## Seek bar being used in `d2l-video` and `d2l-audio`
<img width="930" alt="Screen Shot 2020-06-29 at 9 22 54 AM" src="https://user-images.githubusercontent.com/13937038/86017847-29068380-b9ea-11ea-8ead-ed7ee176b0c2.png">

<img width="591" alt="Screen Shot 2020-06-29 at 9 22 41 AM" src="https://user-images.githubusercontent.com/13937038/86017838-2572fc80-b9ea-11ea-85bd-24a6731e992c.png">
