### PR TITLE
Dispatch position-change event on change

### DIFF
--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -258,6 +258,7 @@ Polymer({
 	},
 
 	_onTrack: function(event) {
+		this.dispatchEvent(new CustomEvent('position-change', { bubbles: true, composed: true }));
 		event.stopPropagation();
 		switch (event.detail.state) {
 			case 'start':

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-seek-bar",
   "name": "@d2l/seek-bar",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "scripts": {
     "lint": "npm run lint:wc && npm run lint:js",
     "lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html",


### PR DESCRIPTION
Previously, position-change event was only dispatched when a
key press was used to change the position of the seek bar. When
the seekbar was in the process of being dragged, it only dispatched
an event at the beginning and end of the drag.

With this change, whenever the value of the seekbar changes, it will
dispatch the position-change event.