### PR TITLE
Remove dependency on old d2l-colors repo

### DIFF
--- a/d2l-progress.js
+++ b/d2l-progress.js
@@ -1,7 +1,7 @@
+import '@brightspace-ui/core/components/colors/colors.js'
 import '@polymer/polymer/polymer-legacy.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import { IronRangeBehavior } from '@polymer/iron-range-behavior/iron-range-behavior.js';
-import 'd2l-colors/d2l-colors.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 const $_documentContainer = document.createElement('template');
 

--- a/d2l-progress.js
+++ b/d2l-progress.js
@@ -1,4 +1,4 @@
-import '@brightspace-ui/core/components/colors/colors.js'
+import '@brightspace-ui/core/components/colors/colors.js';
 import '@polymer/polymer/polymer-legacy.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import { IronRangeBehavior } from '@polymer/iron-range-behavior/iron-range-behavior.js';

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -5,7 +5,7 @@ Polymer-based web component for a D2L seek-bar
 */
 import '@polymer/polymer/polymer-legacy.js';
 
-import '@brightspace-ui/core/components/colors/colors.js'
+import '@brightspace-ui/core/components/colors/colors.js';
 import { IronRangeBehavior } from '@polymer/iron-range-behavior/iron-range-behavior.js';
 import { IronA11yKeysBehavior } from '@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
 import './d2l-progress.js';

--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -5,9 +5,9 @@ Polymer-based web component for a D2L seek-bar
 */
 import '@polymer/polymer/polymer-legacy.js';
 
+import '@brightspace-ui/core/components/colors/colors.js'
 import { IronRangeBehavior } from '@polymer/iron-range-behavior/iron-range-behavior.js';
 import { IronA11yKeysBehavior } from '@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
-import 'd2l-colors/d2l-colors.js';
 import './d2l-progress.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 const $_documentContainer = document.createElement('template');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d2l/seek-bar",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -811,14 +811,6 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "d2l-colors": {
-      "version": "github:BrightspaceUI/colors#e5697963f1f742428c9ef4d79e6324f35ef131a3",
-      "from": "github:BrightspaceUI/colors#semver:^4",
-      "requires": {
-        "@brightspace-ui/core": "^1",
-        "@polymer/polymer": "^3.0.0"
       }
     },
     "d2l-intl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d2l/seek-bar",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -121,18 +121,52 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-tg5oGswWVWRPzirDFBD4w5qRQ7yDkFMcsfiaRnDgDtTJFGNFOuUt8eT/qa6MTJQpKBsk8W6HF/oEBV7WBnBetw==",
+      "version": "1.230.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.230.0.tgz",
+      "integrity": "sha512-CL2/2XT9jY3hfngYpj3Fq+Ey2TKrI1/TloTwPmZqPEOCP15fyleNpgY+YS9IMB5zCJ798ePbxA7Qu9G0McNqDA==",
       "requires": {
-        "@webcomponents/shadycss": "^1",
-        "@webcomponents/webcomponentsjs": "^2",
-        "d2l-intl": "^2",
-        "intl-messageformat": "^2.2.0",
+        "@brightspace-ui/intl": "^3",
+        "@formatjs/intl-pluralrules": "^1",
+        "@open-wc/dedupe-mixin": "^1",
+        "focus-visible": "^5",
+        "ifrau": "^0.39",
+        "intl-messageformat": "^7",
         "lit-element": "^2",
+        "lit-html": "^1",
         "prismjs": "^1",
         "resize-observer-polyfill": "^1"
       }
+    },
+    "@brightspace-ui/intl": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.8.0.tgz",
+      "integrity": "sha512-OX90skLUDc5OpYsDVB37IKP1mI5L+XQ8uwz9m9x90/1c7dQiI8A248/1pbHy/+iOWygxnOjhN+Vjwk6N8Wz78g=="
+    },
+    "@formatjs/intl-pluralrules": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
+      "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
+      "requires": {
+        "@formatjs/intl-utils": "^2.3.0"
+      }
+    },
+    "@formatjs/intl-unified-numberformat": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.7.tgz",
+      "integrity": "sha512-KnWgLRHzCAgT9eyt3OS34RHoyD7dPDYhRcuKn+/6Kv2knDF8Im43J6vlSW6Hm1w63fNq3ZIT1cFk7RuVO3Psag==",
+      "requires": {
+        "@formatjs/intl-utils": "^2.3.0"
+      }
+    },
+    "@formatjs/intl-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
+      "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
+    },
+    "@open-wc/dedupe-mixin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.0.tgz",
+      "integrity": "sha512-UfdK1MPnR6T7f3svzzYBfu3qBkkZ/KsPhcpc3JYhsUY4hbpwNF9wEQtD4Z+/mRqMTJrKg++YSxIxE0FBhY3RIw=="
     },
     "@polymer/app-layout": {
       "version": "3.1.0",
@@ -481,7 +515,8 @@
     "@webcomponents/webcomponentsjs": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.3.0.tgz",
-      "integrity": "sha512-sR6FOrNnnncRuoJDqq9QxtRsJMbIvASw4vnJwIYKVlKO3AMc+NAr/bIQNnUiTTE9pBDTJkFpVaUdjJaRdsjmyA=="
+      "integrity": "sha512-sR6FOrNnnncRuoJDqq9QxtRsJMbIvASw4vnJwIYKVlKO3AMc+NAr/bIQNnUiTTE9pBDTJkFpVaUdjJaRdsjmyA==",
+      "dev": true
     },
     "accessibility-developer-tools": {
       "version": "2.12.0",
@@ -812,11 +847,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "d2l-intl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/d2l-intl/-/d2l-intl-2.1.0.tgz",
-      "integrity": "sha512-mwKU0yn7YS8n7OAhfUPtGiWGnYNrR3b/kxmrp9hdwoDBTDWDObpIrxTkZBF1yaOSK4jDnd813t3gu2PkJmBysQ=="
     },
     "debug": {
       "version": "4.1.1",
@@ -1167,6 +1197,11 @@
         "write": "^0.2.1"
       }
     },
+    "focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
+    },
     "formatio": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
@@ -1313,6 +1348,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ifrau": {
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/ifrau/-/ifrau-0.39.6.tgz",
+      "integrity": "sha512-vpXVjFSbUxnIh2MEhPLy/il0yDurJladnDxLVlT2Ty8bZ30KoDgJRadzJ6SHeBXFLxP98e/IeajMUmlzW5pGpw=="
+    },
     "ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
@@ -1363,18 +1403,27 @@
         "through": "^2.3.6"
       }
     },
+    "intl-format-cache": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.3.1.tgz",
+      "integrity": "sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
+    },
     "intl-messageformat": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
-      "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-7.8.4.tgz",
+      "integrity": "sha512-yS0cLESCKCYjseCOGXuV4pxJm/buTfyCJ1nzQjryHmSehlptbZbn9fnlk1I9peLopZGGbjj46yHHiTAEZ1qOTA==",
       "requires": {
-        "intl-messageformat-parser": "1.4.0"
+        "intl-format-cache": "^4.2.21",
+        "intl-messageformat-parser": "^3.6.4"
       }
     },
     "intl-messageformat-parser": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
-      "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.6.4.tgz",
+      "integrity": "sha512-RgPGwue0mJtoX2Ax8EmMzJzttxjnva7gx0Q7mKJ4oALrTZvtmCeAw5Msz2PcjW4dtCh/h7vN/8GJCxZO1uv+OA==",
+      "requires": {
+        "@formatjs/intl-unified-numberformat": "^3.2.0"
+      }
     },
     "is-arguments": {
       "version": "1.0.4",
@@ -1499,17 +1548,17 @@
       }
     },
     "lit-element": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.2.1.tgz",
-      "integrity": "sha512-ipDcgQ1EpW6Va2Z6dWm79jYdimVepO5GL0eYkZrFvdr0OD/1N260Q9DH+K5HXHFrRoC7dOg+ZpED2XE0TgGdXw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
+      "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
       "requires": {
-        "lit-html": "^1.0.0"
+        "lit-html": "^1.1.1"
       }
     },
     "lit-html": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.1.2.tgz",
-      "integrity": "sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
+      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
     },
     "lodash": {
       "version": "4.17.15",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "type-detect": "1.0.0"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^1.230.0",
+    "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
     "@polymer/iron-flex-layout": "^3.0.0-pre.18",
     "@polymer/iron-range-behavior": "^3.0.0-pre.18",
-    "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
     "@polymer/polymer": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-seek-bar",
   "name": "@d2l/seek-bar",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "scripts": {
     "lint": "npm run lint:wc && npm run lint:js",
     "lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "type-detect": "1.0.0"
   },
   "dependencies": {
-    "d2l-colors": "BrightspaceUI/colors#semver:^4",
+    "@brightspace-ui/core": "^1",
     "@polymer/iron-flex-layout": "^3.0.0-pre.18",
     "@polymer/iron-range-behavior": "^3.0.0-pre.18",
     "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",


### PR DESCRIPTION
Just getting rid of the dependency on the d2l-colors repo. It should also get deleted from the BSI package-lock as this was the last hold out 🎉 
D2l-colors depended on core anyways, so it's a net zero in terms of the lit migration.