### PR TITLE
US137872 - Update palette colours to darken Ferrite and other grey tones

### DIFF
--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -21,8 +21,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 				@apply --layout-center;
 				display: block;
 
-				--d2l-color-corundum-65-opacity: rgba(181, 189, 194, 0.65);
-				--d2l-color-galena-88-opacity: rgba(134, 140, 143, 0.88);
+				--d2l-color-corundum-65-opacity: rgba(177, 185, 190, 0.65);
+				--d2l-color-galena-88-opacity: rgba(110, 116, 119, 0.88);
 
 				--calculated-d2l-seek-bar-height: var(--d2l-seek-bar-height, 6px);
 				--calculated-d2l-knob-size: var(--d2l-knob-size, 32px);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-seek-bar",
   "name": "@d2l/seek-bar",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "scripts": {
     "lint": "npm run lint:wc && npm run lint:js",
     "lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html",


### PR DESCRIPTION
This PR makes the following colour changes:

- Corundum - #b5bdc2, rgba(181, 189, 194, 0.2) -> #B1B9BE, rgba(177, 185, 190, 0.2)

- Chromite- #9ea5a9 -> #90989d

- Galena - #868c8f -> #6e7477

- Tungsten - #6e7376 -> #494C4E

- Ferrite - #494c4e -> #202122


Note that icons in the old Ferrite (494c4e) will remain the same colour (new Tungsten).